### PR TITLE
NA-598 — Knowledge base e padronização: creditcard-warder

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": ["Bash(npm install)", "Bash(npm test)", "Bash(npm run build)"],
+    "deny": ["Bash(rm -rf:*)"]
+  }
+}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,56 @@
+# NA-598 — quality gates CONSULTIVOS. Rodam em PR, NUNCA bloqueiam (continue-on-error).
+# Repo é uma lib npm sem deploy próprio (sem serverless.yml/Dockerfile) — nada quebra.
+name: Quality Gates (consultivo)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # gitleaks direto (redact mascara valores); consultivo: não falha o job.
+      - name: gitleaks
+        continue-on-error: true
+        run: |
+          docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:v8.30.1 \
+            detect --source /repo --redact --no-banner --exit-code 0 --report-path /repo/gitleaks-report.json || true
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+          if-no-files-found: ignore
+
+  sast:
+    name: SAST (Semgrep OSS)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    container:
+      image: semgrep/semgrep:1.169.0
+    steps:
+      - uses: actions/checkout@v4
+      - name: semgrep
+        continue-on-error: true
+        run: semgrep scan --config p/javascript --config p/security-audit --metrics=off . || true
+
+  deps:
+    name: Dependency Scan (Trivy)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: trivy
+        continue-on-error: true
+        run: |
+          docker run --rm -v "$PWD:/repo" aquasec/trivy:0.72.0 \
+            fs --scanners vuln --severity HIGH,CRITICAL --exit-code 0 /repo || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
 node_modules
 *.log
 
+# Config local da sessão (modelo Fable) — não versionar
+.claude/settings.local.json
+
+# relatório do gitleaks (gerado no CI)
+gitleaks-report.json
+
+# understand-anything: manter knowledge-graph.json; ignorar scratch
+.understand-anything/intermediate/
+.understand-anything/tmp/
+.understand-anything/.trash-*/
+.understand-anything/.understandignore
+
+# graphify: manter graph.json/GRAPH_REPORT.md/triage-info.json; ignorar caches AST
+graphify-out/.graphify_*
+graphify-out/cache/

--- a/.understand-anything/config.json
+++ b/.understand-anything/config.json
@@ -1,0 +1,1 @@
+{"outputLanguage": "en"}

--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,0 +1,86 @@
+{
+  "version": "1.0.0",
+  "gitCommitHash": "be3042af4d97a07a4d03efc8617a004c489c111e",
+  "generatedAt": "2026-07-18T21:53:00.468Z",
+  "files": {
+    "index.js": {
+      "filePath": "index.js",
+      "contentHash": "b3b2211cff704d7d758af49a2e9cd3d4af14e1d06a71063bbef2f3b831638e6c",
+      "functions": [
+        {
+          "name": "CredircardWarder",
+          "params": [
+            "number"
+          ],
+          "exported": false,
+          "lineCount": 83
+        }
+      ],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 109,
+      "hasStructuralAnalysis": true
+    },
+    "test/test.js": {
+      "filePath": "test/test.js",
+      "contentHash": "518ff64ecb967433455d16693846eb549b37d7cfb997ec914fbb6defdae746f0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 112,
+      "hasStructuralAnalysis": true
+    },
+    "package.json": {
+      "filePath": "package.json",
+      "contentHash": "2c3eeccde4ad81a3ac1e3add04b537a59c6c5a8e19c9a2f7af3be22b42a4e147",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 74,
+      "hasStructuralAnalysis": true
+    },
+    "bower.json": {
+      "filePath": "bower.json",
+      "contentHash": "c48b3f1f64fe57d10a23dc333c3a49fd2c65e29257a1fbd1cfbbf1a60f7eac74",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 27,
+      "hasStructuralAnalysis": true
+    },
+    "rollup.config.js": {
+      "filePath": "rollup.config.js",
+      "contentHash": "72fc9863793ac814cef28157e41db7fa422db754cbc2cec98f32327ac3cea454",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 23,
+      "hasStructuralAnalysis": true
+    },
+    "dist/creditcard-warder.min.js": {
+      "filePath": "dist/creditcard-warder.min.js",
+      "contentHash": "f2c71ff83a22a94fed76a245310b3e7dbb2dc7becd0cd0eb4d658f3a94d7626f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": true
+    },
+    "README.md": {
+      "filePath": "README.md",
+      "contentHash": "2c836fb5ecf19a1b68b8c66d04afcb5fa86ea84806fc3e19b9e4fd9ee8d6752d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 62,
+      "hasStructuralAnalysis": true
+    }
+  }
+}

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -1,0 +1,187 @@
+{
+    "version": "1.0.0",
+    "project": {
+        "name": "creditcard-warder",
+        "languages": ["javascript"],
+        "frameworks": [],
+        "description": "Standalone JS library (published to npm as `creditcard-warder`) that identifies a Brazilian/global credit card brand from a card number (BIN/regex table) and validates the number via Luhn checksum. No server, no database, no AWS resources of its own — a pure client+server side validation library consumed as a dependency by the monolito (apoia.se, both Node backend and browser bundle) and by apoiase-client (React forms).",
+        "analyzedAt": "2026-07-14T15:20:00-03:00",
+        "gitCommitHash": "daef10254f3d8e7223a004556e0b6a001f1f9b02"
+    },
+    "nodes": [
+        {
+            "id": "file:index.js",
+            "type": "file",
+            "name": "index.js",
+            "filePath": "index.js",
+            "summary": "Entry point. Defines the CredircardWarder constructor with a hardcoded `rules` table (regex pattern + valid lengths + cvcLength per brand: elo, hipercard, aura, visaelectron, maestro, forbrugsforeningen, dankort, visa, mastercard, amex, dinersclub, discover, unionpay, jcb, other) and exposes getBrand()/validate() via a factory function.",
+            "tags": ["core", "public-api"],
+            "complexity": "simple"
+        },
+        {
+            "id": "function:index.js:CredircardWarder",
+            "type": "function",
+            "name": "CredircardWarder (constructor)",
+            "filePath": "index.js",
+            "summary": "Constructor that stores the input number and the static `rules` array (14 brand patterns + fallback 'other'). Note the typo in the internal name (Credircard, missing 'e') — harmless, not part of the public surface.",
+            "tags": ["core"],
+            "complexity": "simple"
+        },
+        {
+            "id": "function:index.js:getRule",
+            "type": "function",
+            "name": "getRule",
+            "filePath": "index.js",
+            "summary": "Uses lodash.find to return the first rule whose regex matches the stored number, falling back to the 'other' rule when nothing matches.",
+            "tags": ["helper"],
+            "complexity": "simple"
+        },
+        {
+            "id": "function:index.js:getBrand",
+            "type": "function",
+            "name": "getBrand",
+            "filePath": "index.js",
+            "summary": "Public method. Returns the `type` string of the matched rule (e.g. 'visa', 'mastercard', 'other').",
+            "tags": ["public-api"],
+            "complexity": "simple"
+        },
+        {
+            "id": "function:index.js:validate",
+            "type": "function",
+            "name": "validate",
+            "filePath": "index.js",
+            "summary": "Public method. Delegates to the `luhn` package (luhn.validate) to check the Luhn checksum of the stored number — does not itself implement Luhn.",
+            "tags": ["public-api"],
+            "complexity": "simple"
+        },
+        {
+            "id": "file:test/test.js",
+            "type": "file",
+            "name": "test.js",
+            "filePath": "test/test.js",
+            "summary": "Mocha/assert unit tests covering getBrand() across all 14 supported brands plus invalid input, using well-known public test/example card numbers (not real PANs — same fixtures used across the payments-testing ecosystem).",
+            "tags": ["test"],
+            "complexity": "simple"
+        },
+        {
+            "id": "config:package.json",
+            "type": "config",
+            "name": "package.json",
+            "filePath": "package.json",
+            "summary": "npm manifest, published as `creditcard-warder` v1.0.1. Runtime deps: lodash.find, luhn. Dev: mocha, rollup (+ plugins), xo (linter), testling. `xo` config disables esnext (ES5 style).",
+            "tags": ["config", "manifest"],
+            "complexity": "simple"
+        },
+        {
+            "id": "config:bower.json",
+            "type": "config",
+            "name": "bower.json",
+            "filePath": "bower.json",
+            "summary": "Bower manifest (legacy frontend package manager) exposing the same lib for browser consumption — mirrors how apoia.se's monolito includes it (public/lib/creditcard-warder/dist/creditcard-warder.min.js).",
+            "tags": ["config", "manifest", "legacy"],
+            "complexity": "simple"
+        },
+        {
+            "id": "config:rollup.config.js",
+            "type": "config",
+            "name": "rollup.config.js",
+            "filePath": "rollup.config.js",
+            "summary": "Rollup build config bundling index.js into a UMD bundle (dist/creditcard-warder.min.js, global name CreditcardWarder) via node-resolve + commonjs + uglify.",
+            "tags": ["config", "build"],
+            "complexity": "simple"
+        },
+        {
+            "id": "file:dist/creditcard-warder.min.js",
+            "type": "file",
+            "name": "creditcard-warder.min.js",
+            "filePath": "dist/creditcard-warder.min.js",
+            "summary": "Committed prebuilt UMD bundle — this is the exact artifact the monolito's browser bundle (include-scripts.js) references from public/lib/.",
+            "tags": ["build-artifact"],
+            "complexity": "simple"
+        },
+        {
+            "id": "document:README.md",
+            "type": "document",
+            "name": "README.md",
+            "filePath": "README.md",
+            "summary": "Accurately documents this repo (unlike installment-calculator's README, which wrongly documents creditcard-warder instead — a known cross-repo doc-drift pair). Lists supported brands and Node + browser usage.",
+            "tags": ["docs"],
+            "complexity": "simple"
+        }
+    ],
+    "edges": [
+        { "source": "file:index.js", "target": "function:index.js:CredircardWarder", "type": "contains", "weight": 1.0 },
+        { "source": "file:index.js", "target": "function:index.js:getRule", "type": "contains", "weight": 1.0 },
+        { "source": "file:index.js", "target": "function:index.js:getBrand", "type": "contains", "weight": 1.0 },
+        { "source": "file:index.js", "target": "function:index.js:validate", "type": "contains", "weight": 1.0 },
+        { "source": "function:index.js:getBrand", "target": "function:index.js:getRule", "type": "calls", "weight": 0.8 },
+        { "source": "function:index.js:validate", "target": "function:index.js:getBrand", "type": "related_to", "weight": 0.3 },
+        { "source": "file:test/test.js", "target": "file:index.js", "type": "imports", "weight": 0.7 },
+        { "source": "file:index.js", "target": "file:test/test.js", "type": "tested_by", "weight": 0.5 },
+        { "source": "config:package.json", "target": "file:index.js", "type": "configures", "weight": 0.6 },
+        { "source": "config:rollup.config.js", "target": "file:index.js", "type": "configures", "weight": 0.6 },
+        { "source": "config:rollup.config.js", "target": "file:dist/creditcard-warder.min.js", "type": "produces", "weight": 0.7 },
+        { "source": "config:bower.json", "target": "file:dist/creditcard-warder.min.js", "type": "depends_on", "weight": 0.6 },
+        { "source": "document:README.md", "target": "file:index.js", "type": "documents", "weight": 0.5 }
+    ],
+    "layers": [
+        {
+            "id": "layer:core-logic",
+            "name": "Core Logic",
+            "description": "Brand detection (regex table) and Luhn validation — index.js and its functions.",
+            "nodeIds": [
+                "file:index.js",
+                "function:index.js:CredircardWarder",
+                "function:index.js:getRule",
+                "function:index.js:getBrand",
+                "function:index.js:validate"
+            ]
+        },
+        {
+            "id": "layer:build-and-package",
+            "name": "Build & Package",
+            "description": "npm/bower manifests, rollup config and the committed browser bundle used to ship this as a dual Node+browser library.",
+            "nodeIds": [
+                "config:package.json",
+                "config:bower.json",
+                "config:rollup.config.js",
+                "file:dist/creditcard-warder.min.js"
+            ]
+        },
+        {
+            "id": "layer:tests-and-docs",
+            "name": "Tests & Docs",
+            "description": "Unit tests (public test card fixtures) and accurate README.",
+            "nodeIds": [
+                "file:test/test.js",
+                "document:README.md"
+            ]
+        }
+    ],
+    "tour": [
+        {
+            "order": 1,
+            "title": "What this package does",
+            "description": "index.js's `rules` array is the whole product: 14 brand regex patterns (Elo, Hipercard, Aura, Visa Electron, Maestro, Forbrugsforeningen, Dankort, Visa, Mastercard, Amex, Dinersclub, Discover, Unionpay, JCB) plus an 'other' fallback. getBrand() returns the matched type; validate() checks the Luhn checksum via the `luhn` package.",
+            "nodeIds": ["file:index.js", "function:index.js:getBrand", "function:index.js:validate"]
+        },
+        {
+            "order": 2,
+            "title": "How brand matching works",
+            "description": "getRule() uses lodash.find to test the number against each regex in order, first match wins; falls back to 'other' if nothing matches (or the input is empty/non-numeric).",
+            "nodeIds": ["function:index.js:getRule", "function:index.js:CredircardWarder"]
+        },
+        {
+            "order": 3,
+            "title": "Tests use public test PANs",
+            "description": "test/test.js exercises every brand with well-known public test/example card numbers (industry-standard test BINs, not real cardholder data) — relevant for PCI-scope review of this repo: no real PAN present, only synthetic test values matching the same fixtures used across the payments-testing ecosystem.",
+            "nodeIds": ["file:test/test.js"]
+        },
+        {
+            "order": 4,
+            "title": "Shipped two ways: Node module and browser bundle",
+            "description": "package.json publishes it to npm (used server-side by apoia.se's mundipagg/subscription.js and directly by apoiase-client's card-number/card-cvv form fields); bower.json + rollup.config.js additionally produce dist/creditcard-warder.min.js, the exact file apoia.se's include-scripts.js loads client-side (public/lib/creditcard-warder/dist/...). No AWS resource, no serverless.yml, no deploy of its own — it is pure library code consumed by other repos.",
+            "nodeIds": ["config:package.json", "config:bower.json", "config:rollup.config.js", "file:dist/creditcard-warder.min.js", "document:README.md"]
+        }
+    ]
+}

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,0 +1,6 @@
+{
+  "lastAnalyzedAt": "2026-07-14T15:17:11-03:00",
+  "gitCommitHash": "be3042af4d97a07a4d03efc8617a004c489c111e",
+  "version": "1.0.0",
+  "analyzedFiles": 3
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# creditcard-warder
+
+Biblioteca JS standalone (publicada no npm como `creditcard-warder`) que identifica a bandeira
+de um cartão de crédito a partir do número (tabela de regex por BIN — Elo, Hipercard, Aura,
+Visa Electron, Maestro, Forbrugsforeningen, Dankort, Visa, Mastercard, Amex, Dinersclub,
+Discover, Unionpay, JCB) e valida o número via checksum de Luhn (delega pro pacote `luhn`).
+Sem servidor, sem banco, sem recurso AWS próprio — puro código de validação.
+
+> **Estado (NA-598, 2026-07-14):** não é um serviço deployado nem um satélite serverless —
+> é uma **lib dependência**, consumida via `require`/`import` por dois repos vivos:
+> `apoia.se` (monolito, server-side em `modules/mundipagg/subscription.js` + client-side via
+> bundle vendorizado em `public/lib/`) e `apoiase-client` (formulário de cartão, React). O
+> `apoiase-context-layer` lista este repo no subgrafo "Serverless — Cobrança" da topologia —
+> **divergência**: não há compute próprio a validar; ver `docs/prc/scan/2026-07-14-scan.md`.
+
+## Comandos
+
+```bash
+npm test              # xo (lint) + mocha --ui tdd (test/test.js)
+npm run build          # rollup --config → dist/creditcard-warder.min.js (UMD, browser)
+npm run watch          # rollup --config --watch
+```
+
+Sem deploy — não há pipeline de deploy, CI existente ou infraestrutura a orquestrar.
+
+## Arquitetura
+
+Um único arquivo de lógica (`index.js`):
+- **`CredircardWarder`** (constructor, nome com typo interno — não é parte da API pública) —
+  guarda o número e a tabela `rules` (14 bandeiras + fallback `other`).
+- **`getRule()`** — usa `lodash.find` para achar a primeira regra cujo regex bate com o número;
+  cai em `other` se nada bater.
+- **`getBrand()`** — API pública; retorna o `type` da regra encontrada.
+- **`validate()`** — API pública; delega para `luhn.validate()` (não implementa Luhn aqui).
+
+Empacotado de duas formas: `package.json` publica no npm (consumo Node/bundlers); `bower.json` +
+`rollup.config.js` geram `dist/creditcard-warder.min.js` (UMD) para uso direto em browser —
+esse é o artefato que o monolito `apoia.se` vendoriza em `public/lib/`.
+
+## Contexto de domínio
+
+Detecção de bandeira + validação de número de cartão é etapa do fluxo de **checkout/cobrança**
+(Apoio via cartão de crédito) — ver `apoiase-context-layer` →
+`engineering/billing-operations.md` e `infrastructure/overview.md` (topologia "Serverless —
+Cobrança", onde este repo aparece listado — ver nota de divergência acima e no scan).
+
+## Convenções
+
+- Commits em português natural com `NA-598` no texto durante o rollout; branch
+  `big-picture/NA-598-creditcard-warder`.
+- Repo GitHub (SoT). Merge **só pela UI do GitHub** com review humano (nunca via API/gh merge).
+- CI: `.github/workflows/quality-gates.yml` 100% **consultivo** (nunca bloqueia; não há deploy
+  a preservar).
+
+## Knowledge graph
+
+- `.understand-anything/knowledge-graph.json` (montado à mão — repo pequeno, ~900 palavras,
+  sem pipeline de subagents)
+- `graphify-out/graph.json` + `GRAPH_REPORT.md` (50 nós do `package.json`; graphify concluiu
+  que o corpus cabe num único contexto e não exigiu grafo do código)
+
+## Segurança (ver docs/prc/)
+
+- Sem secret no HEAD (`gitleaks detect`, working tree + 59 commits de histórico) — nada a
+  ignorar/rotacionar.
+- `test/test.js` usa números de cartão de **teste públicos** (mesmos BINs de exemplo usados na
+  indústria de pagamentos, ex. Stripe/Braintree) — não são PANs reais; relevante por ser um
+  repo de escopo PCI (validação de cartão), documentado em `docs/prc/security/PRC.md` (SEC9)
+  para não confundir com secret real caso outro scanner acuse.
+- Devdeps desatualizadas (`xo@0.15.0` de 2016, `rollup@^0.66.2`, `mocha@^3.2.0`) — débito de
+  higiene, sem urgência (repo estável, tabela de bandeiras não muda com frequência).

--- a/docs/prc/aws/PRC.md
+++ b/docs/prc/aws/PRC.md
@@ -1,0 +1,12 @@
+# PRC — AWS (creditcard-warder)
+
+- [x] **AWS1** **Sem deploy** — não há `serverless.yml`, Dockerfile, `.tf` ou qualquer IaC no
+  repo. Confirmado por busca na árvore.
+- [x] **AWS2** Cruzamento com snapshots Steampipe da rodada (lambdas/cfn-stacks/s3/sqs/
+  apigwrest/apigwv2/eventrules/sns/dynamodb): **zero ocorrências** de "creditcard" — não existe
+  recurso AWS próprio com esse nome.
+- [x] **AWS3** É consumido como **dependência de código** (npm) por `apoia.se` (monolito, prod)
+  e `apoiase-client` — não como serviço/endpoint separado. Ver `docs/prc/scan/2026-07-14-scan.md`.
+- [ ] **AWS4** `apoiase-context-layer` (`infrastructure/overview.md`) lista este repo no
+  subgrafo "Serverless — Cobrança" — divergência a corrigir no próximo review do context-layer
+  (fora do escopo desta PR, que não edita esse repo).

--- a/docs/prc/github/PRC.md
+++ b/docs/prc/github/PRC.md
@@ -1,0 +1,15 @@
+# PRC — Repositório / CI (creditcard-warder)
+
+Repo GitHub (SoT).
+
+- [x] **GH1** Branch `big-picture/NA-598-creditcard-warder` a partir de `master` (default do
+  repo).
+- [x] **GH2** `.github/workflows/quality-gates.yml` consultivo (secret-scan/SAST/SCA,
+  `continue-on-error` em todo step, nunca bloqueia PR).
+- [x] **GH3** Sem workflow/deploy pré-existente a preservar — repo não tinha `.github/` antes
+  deste rollout.
+- [ ] **GH4** Reviewers do PR = time (não definidos nesta rodada) — add reviewer manual.
+- [ ] **GH5** Devdeps antigas (`xo@0.15.0`, `rollup@^0.66.2`, `mocha@^3.2.0`, `testling`
+  descontinuado) — sem Renovate/Dependabot configurado; recomendação aberta, sem urgência.
+- [x] **GH6** Repo tem 2 forks/remotes visíveis no clone local (`origin` = apoiase,
+  `upstream` = `arielpchara/creditcard-info`, autor original) — histórico preservado, sem ação.

--- a/docs/prc/observability/PRC.md
+++ b/docs/prc/observability/PRC.md
@@ -1,0 +1,5 @@
+# PRC — Observability (creditcard-warder)
+
+- [x] **OBS1** N/A — biblioteca pura, sem processo próprio, sem log, sem métrica. Observabilidade
+  (se necessária) é responsabilidade de quem consome a lib (`apoia.se`, `apoiase-client`), não
+  deste repo.

--- a/docs/prc/scan/2026-07-14-scan.md
+++ b/docs/prc/scan/2026-07-14-scan.md
@@ -1,0 +1,86 @@
+# Scan código → realidade — creditcard-warder (2026-07-14)
+
+Fontes: `.understand-anything/knowledge-graph.json`, `graphify-out/graph.json` +
+`GRAPH_REPORT.md`, snapshots Steampipe do rollout (cfn-stacks/lambdas/s3/sqs/apigwrest/
+apigwv2/eventrules/sns/dynamodb, formato `{columns,rows,metadata}`), `apoiase-context-layer`
+(`infrastructure/overview.md`). **Sem Steampipe novo rodado** — cruzamento feito com os
+snapshots já coletados nesta rodada (26 repos GH).
+
+Legenda: ✅ confirmado · ⚠️ divergência · ❓ validar · ❌ não encontrado
+
+## O que o código faz
+
+Biblioteca JS standalone (`creditcard-warder`, publicada no npm) que identifica a bandeira de
+um cartão de crédito a partir do número (tabela de regex por BIN — Elo, Hipercard, Aura, Visa
+Electron, Maestro, Forbrugsforeningen, Dankort, Visa, Mastercard, Amex, Dinersclub, Discover,
+Unionpay, JCB, fallback "other") e valida o número via checksum de Luhn (delega pro pacote
+`luhn`). `index.js` é o único módulo de lógica; empacotado tanto para Node (`require`) quanto
+para browser via bower + rollup (`dist/creditcard-warder.min.js`, UMD).
+
+## Onde é usado (código → realidade, cross-repo)
+
+- ✅ **apoia.se (monolito)** — dependência direta em `package.json` (`"creditcard-warder":
+  "^1.0.1"`). Uso server-side em `modules/mundipagg/subscription.js` (`require('creditcard-warder')`,
+  parte do fluxo de assinatura/cobrança Mundipagg). Uso client-side: `include-scripts.js` referencia
+  `public/lib/creditcard-warder/dist/creditcard-warder.min.js` — o bundle bower/rollup deste
+  repo é vendorizado no monolito para validação de bandeira/Luhn no formulário de checkout.
+- ✅ **apoiase-client** (frontend novo) — dependência direta em `packages/client/package.json`;
+  importado em `components/core/forms/fields/card-number/index.jsx` e `.../card-cvv/index.jsx`
+  para exibir o ícone da bandeira e validar o número em tempo real no formulário.
+- ❓ Nenhum outro repo clonado nesta task referencia `creditcard-warder` (grep completo em
+  `repos/` + `repos-triage/` só retorna os dois acima).
+
+## Serverless.yml / deploy
+
+**❌ Não existe `serverless.yml`, Dockerfile, `.tf` ou qualquer IaC neste repo** — confirmado
+(`find` na árvore). Não há `.github/workflows` pré-existente. `package.json` não tem
+AWS SDK nem qualquer dependência de infra.
+
+Cruzamento com os snapshots Steampipe (`lambdas.json`, `cfn-stacks.json`, `s3.json`, `sqs.json`,
+`apigwrest.json`, `apigwv2.json`, `eventrules.json`, `sns.json`, `dynamodb.json`) coletados
+nesta rodada: **zero ocorrências** de "creditcard" em qualquer um — confirma que **não há
+recurso AWS próprio** deployado com esse nome (não é Lambda, não é stack, não é fila).
+
+## ⚠️ Divergência de arquitetura (context-layer × código)
+
+O `apoiase-context-layer` (`infrastructure/overview.md`, diagrama de topologia) posiciona
+`creditcard-warder` dentro do subgrafo **"Serverless — Cobrança"**, ao lado de
+`charges-consolidate`, `antifraude-autoblock`, `pledges-generate` etc. — sugerindo que seria
+um serviço/Lambda deployado como os demais satélites de cobrança.
+
+**Não é.** Este repo é uma **biblioteca pura sem compute próprio** — consumida como dependência
+de código (require/import) pelo monolito e pelo apoiase-client, não como um serviço chamado em
+runtime (sem endpoint HTTP, sem fila, sem trigger). O diagrama do context-layer está correto no
+sentido de que a *funcionalidade* (detecção de bandeira/validação) participa do fluxo de
+cobrança, mas incorreto ao agrupá-lo como item serverless implantado — recomendação: mover a
+entrada para uma camada tipo "Libs compartilhadas" ou anotar como "lib, sem deploy próprio" no
+próximo review do context-layer (fora do escopo desta PR, que não edita esse repo).
+
+## Terceiros
+
+Nenhuma chamada de rede. Deps runtime: `lodash.find`, `luhn` (ambos algoritmos puros, sem I/O).
+
+## PCI — nota sobre fixtures de teste
+
+`test/test.js` contém números de cartão usados nos testes (ex.: `4024007175430676` para Visa,
+`5141581454983717`/`2221009999999999` etc. para Mastercard). São **números de teste públicos
+padrão da indústria de pagamentos** (mesmos BINs/exemplos usados por Stripe, Braintree e outros
+— não são PANs reais de portador de cartão). `gitleaks detect` (working tree + histórico
+completo, 59 commits) rodou local e **não encontrou nenhum secret** — nenhuma entrada precisou
+ir para o `.gitleaksignore` da raiz da task. Ver `docs/prc/security/PRC.md` (SEC9).
+
+## Veredito de infraestrutura
+
+**Lib pura, sem deploy** — não é GHOST (repo morto sem consumidor) nem serviço vivo: é uma
+dependência de código ativamente usada por dois repos vivos (apoia.se monolito em prod,
+apoiase-client). Não aparece no inventário vivo porque não gera recurso AWS — comportamento
+esperado para uma lib, não um drift.
+
+## Ações sugeridas
+
+- Nenhuma ação de infra (não há infra própria).
+- Sugestão de higiene (fora do escopo desta PR): atualizar `apoiase-context-layer` para não
+  listar `creditcard-warder` como item do subgrafo "Serverless" — é uma lib compartilhada.
+- `xo@0.15.0` (linter, 2016) e `rollup@^0.66.2`/`mocha@^3.2.0` (devDependencies) estão
+  bastante desatualizados — sem urgência dado que o repo é estável e sem mudança de regras de
+  bandeira recente, mas registrar como débito (ver `docs/prc/security/PRC.md`).

--- a/docs/prc/security/PRC.md
+++ b/docs/prc/security/PRC.md
@@ -1,0 +1,22 @@
+# PRC — Security (creditcard-warder)
+
+- [x] **SEC1** Secret scanning no PR (gitleaks, `.github/workflows/quality-gates.yml`, criado
+  neste rollout).
+- [x] **SEC2** SAST no PR (Semgrep, `p/javascript` + `p/security-audit`).
+- [x] **SEC3** SCA no PR (Trivy fs).
+- [x] **SEC9** `gitleaks detect` local (working tree + histórico completo, 59 commits) rodou e
+  **não encontrou nenhum secret** — nada a registrar no `.gitleaksignore` da raiz da task, nada
+  a rotacionar.
+- [x] **SEC-PCI** Repo tem escopo PCI (validação de número de cartão): `test/test.js` usa
+  números de cartão de **teste públicos padrão da indústria de pagamentos** (mesmos exemplos
+  usados por Stripe/Braintree/etc — ex. `4024007175430676` para Visa), **não são PANs reais**.
+  Confirmado manualmente (não são credenciais/dados sensíveis reais) e não flagados pelo
+  gitleaks local; deixar registrado aqui para o caso de outro scanner externo acusar
+  falso-positivo no futuro (mesmo padrão adotado em `sentinel-ai`).
+- [ ] **SEC10** Devdeps desatualizadas (`xo@0.15.0` de 2016, `rollup@^0.66.2`, `mocha@^3.2.0`,
+  `testling` descontinuado) — sem Renovate/Dependabot configurado (bloqueado org-wide por auth
+  upstream, ver CLAUDE.md da task raiz); recomendação aberta, sem urgência dado runtime deps
+  mínimas (`lodash.find`, `luhn`) e código estável.
+- [x] **SEC11** Repo consumido por dois repos vivos em produção (`apoia.se`, `apoiase-client`)
+  — qualquer alteração de lógica de validação exige coordenação com esses times antes de
+  publicar nova versão no npm (não é enforced por CI, é anotação de risco).

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,0 +1,87 @@
+# Graph Report - .  (2026-07-12)
+
+## Corpus Check
+- Corpus is ~905 words - fits in a single context window. You may not need a graph.
+
+## Summary
+- 50 nodes · 44 edges · 12 communities
+- Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
+- Token cost: 0 input · 0 output
+
+## Community Hubs (Navigation)
+- Community 0
+- Community 1
+- Community 2
+- Community 3
+- Community 4
+- Community 5
+- Community 6
+- Community 7
+
+## God Nodes (most connected - your core abstractions)
+1. `scripts` - 5 edges
+2. `testling` - 4 edges
+3. `xo` - 4 edges
+4. `repository` - 3 edges
+5. `main` - 1 edges
+6. `authors` - 1 edges
+7. `license` - 1 edges
+8. `keywords` - 1 edges
+9. `homepage` - 1 edges
+10. `ignore` - 1 edges
+
+## Surprising Connections (you probably didn't know these)
+- None detected - all connections are within the same source files.
+
+## Import Cycles
+- None detected.
+
+## Communities (12 total, 0 thin omitted)
+
+### Community 0 - "Community 0"
+Cohesion: 0.22
+Nodes (8): authors, description, homepage, ignore, keywords, license, main, name
+
+### Community 1 - "Community 1"
+Cohesion: 0.25
+Nodes (7): contributors, description, keywords, license, main, name, version
+
+### Community 2 - "Community 2"
+Cohesion: 0.25
+Nodes (8): devDependencies, mocha, rollup, rollup-plugin-commonjs, rollup-plugin-node-resolve, rollup-plugin-uglify, testling, xo
+
+### Community 3 - "Community 3"
+Cohesion: 0.40
+Nodes (5): scripts, build, test, test-browser, watch
+
+### Community 4 - "Community 4"
+Cohesion: 0.50
+Nodes (4): testling, browsers, files, harness
+
+### Community 5 - "Community 5"
+Cohesion: 0.50
+Nodes (4): xo, envs, esnext, space
+
+### Community 6 - "Community 6"
+Cohesion: 0.67
+Nodes (3): dependencies, lodash.find, luhn
+
+### Community 7 - "Community 7"
+Cohesion: 0.67
+Nodes (3): repository, type, url
+
+## Knowledge Gaps
+- **36 isolated node(s):** `name`, `description`, `main`, `authors`, `license` (+31 more)
+  These have ≤1 connection - possible missing edges or undocumented components.
+
+## Suggested Questions
+_Questions this graph is uniquely positioned to answer:_
+
+- **Why does `devDependencies` connect `Community 2` to `Community 1`?**
+  _High betweenness centrality (0.179) - this node is a cross-community bridge._
+- **Why does `scripts` connect `Community 3` to `Community 1`?**
+  _High betweenness centrality (0.107) - this node is a cross-community bridge._
+- **Why does `testling` connect `Community 4` to `Community 1`?**
+  _High betweenness centrality (0.082) - this node is a cross-community bridge._
+- **What connects `name`, `description`, `main` to the rest of the system?**
+  _36 weakly-connected nodes found - possible documentation gaps or missing edges._

--- a/graphify-out/cost.json
+++ b/graphify-out/cost.json
@@ -1,0 +1,12 @@
+{
+  "runs": [
+    {
+      "date": "2026-07-18T21:52:45Z",
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "files": 6
+    }
+  ],
+  "total_input_tokens": 0,
+  "total_output_tokens": 0
+}

--- a/graphify-out/graph.html
+++ b/graphify-out/graph.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>graphify - graphify-out/graph.html</title>
+<script src="https://unpkg.com/vis-network@9.1.6/standalone/umd/vis-network.min.js"
+        integrity="sha384-Ux6phic9PEHJ38YtrijhkzyJ8yQlH8i/+buBR8s3mAZOJrP1gwyvAcIYl3GWtpX1"
+        crossorigin="anonymous"></script>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: #0f0f1a; color: #e0e0e0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; display: flex; height: 100vh; overflow: hidden; }
+  #graph { flex: 1; }
+  #sidebar { width: 280px; background: #1a1a2e; border-left: 1px solid #2a2a4e; display: flex; flex-direction: column; overflow: hidden; }
+  #search-wrap { padding: 12px; border-bottom: 1px solid #2a2a4e; }
+  #search { width: 100%; background: #0f0f1a; border: 1px solid #3a3a5e; color: #e0e0e0; padding: 7px 10px; border-radius: 6px; font-size: 13px; outline: none; }
+  #search:focus { border-color: #4E79A7; }
+  #search-results { max-height: 140px; overflow-y: auto; padding: 4px 12px; border-bottom: 1px solid #2a2a4e; display: none; }
+  .search-item { padding: 4px 6px; cursor: pointer; border-radius: 4px; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .search-item:hover { background: #2a2a4e; }
+  #info-panel { padding: 14px; border-bottom: 1px solid #2a2a4e; min-height: 140px; }
+  #info-panel h3 { font-size: 13px; color: #aaa; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.05em; }
+  #info-content { font-size: 13px; color: #ccc; line-height: 1.6; }
+  #info-content .field { margin-bottom: 5px; }
+  #info-content .field b { color: #e0e0e0; }
+  #info-content .empty { color: #555; font-style: italic; }
+  .neighbor-link { display: block; padding: 2px 6px; margin: 2px 0; border-radius: 3px; cursor: pointer; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-left: 3px solid #333; }
+  .neighbor-link:hover { background: #2a2a4e; }
+  #neighbors-list { max-height: 160px; overflow-y: auto; margin-top: 4px; }
+  #legend-wrap { flex: 1; overflow-y: auto; padding: 12px; }
+  #legend-wrap h3 { font-size: 13px; color: #aaa; margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.05em; }
+  .legend-item { display: flex; align-items: center; gap: 8px; padding: 4px 0; cursor: pointer; border-radius: 4px; font-size: 12px; }
+  .legend-item:hover { background: #2a2a4e; padding-left: 4px; }
+  .legend-item.dimmed { opacity: 0.35; }
+  .legend-dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
+  .legend-label { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .legend-count { color: #666; font-size: 11px; }
+  #stats { padding: 10px 14px; border-top: 1px solid #2a2a4e; font-size: 11px; color: #555; }
+  #legend-controls { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; padding: 4px 0; }
+  #legend-controls label { display: flex; align-items: center; gap: 6px; cursor: pointer; font-size: 12px; color: #aaa; user-select: none; }
+  #legend-controls label:hover { color: #e0e0e0; }
+  .legend-cb, #select-all-cb { appearance: none; -webkit-appearance: none; width: 14px; height: 14px; border: 1.5px solid #3a3a5e; border-radius: 3px; background: #0f0f1a; cursor: pointer; position: relative; flex-shrink: 0; }
+  .legend-cb:checked, #select-all-cb:checked { background: #4E79A7; border-color: #4E79A7; }
+  .legend-cb:checked::after, #select-all-cb:checked::after { content: ''; position: absolute; left: 3.5px; top: 1px; width: 4px; height: 7px; border: solid #fff; border-width: 0 2px 2px 0; transform: rotate(45deg); }
+  #select-all-cb:indeterminate { background: #4E79A7; border-color: #4E79A7; }
+  #select-all-cb:indeterminate::after { content: ''; position: absolute; left: 2px; top: 5px; width: 8px; height: 2px; background: #fff; border: none; transform: none; }
+</style>
+</head>
+<body>
+<div id="graph"></div>
+<div id="sidebar">
+  <div id="search-wrap">
+    <input id="search" type="text" placeholder="Search nodes..." autocomplete="off">
+    <div id="search-results"></div>
+  </div>
+  <div id="info-panel">
+    <h3>Node Info</h3>
+    <div id="info-content"><span class="empty">Click a node to inspect it</span></div>
+  </div>
+  <div id="legend-wrap">
+    <h3>Communities</h3>
+    <div id="legend-controls">
+      <label><input type="checkbox" id="select-all-cb" checked onchange="toggleAllCommunities(!this.checked)">Select All</label>
+    </div>
+    <div id="legend"></div>
+  </div>
+  <div id="stats">50 nodes &middot; 44 edges &middot; 12 communities</div>
+</div>
+<script>
+const RAW_NODES = [{"id": "bower", "label": "bower.json", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 28.5, "font": {"size": 12, "color": "#ffffff"}, "title": "bower.json", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 8}, {"id": "bower_name", "label": "name", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "name", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 1}, {"id": "bower_description", "label": "description", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "description", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 1}, {"id": "bower_main", "label": "main", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "main", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 1}, {"id": "bower_authors", "label": "authors", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "authors", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 1}, {"id": "bower_license", "label": "license", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "license", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 1}, {"id": "bower_keywords", "label": "keywords", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "keywords", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 1}, {"id": "bower_homepage", "label": "homepage", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "homepage", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 1}, {"id": "bower_ignore", "label": "ignore", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "ignore", "community": 0, "community_name": "Community 0", "source_file": "bower.json", "file_type": "code", "degree": 1}, {"id": "index", "label": "index.js", "color": {"background": "#9C755F", "border": "#9C755F", "highlight": {"background": "#ffffff", "border": "#9C755F"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "index.js", "community": 8, "community_name": "Community 8", "source_file": "index.js", "file_type": "code", "degree": 1}, {"id": "index_credircardwarder_getrule", "label": ".getRule()", "color": {"background": "#BAB0AC", "border": "#BAB0AC", "highlight": {"background": "#ffffff", "border": "#BAB0AC"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": ".getRule()", "community": 9, "community_name": "Community 9", "source_file": "index.js", "file_type": "code", "degree": 1}, {"id": "index_credircardwarder_getbrand", "label": ".getBrand()", "color": {"background": "#BAB0AC", "border": "#BAB0AC", "highlight": {"background": "#ffffff", "border": "#BAB0AC"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": ".getBrand()", "community": 9, "community_name": "Community 9", "source_file": "index.js", "file_type": "code", "degree": 1}, {"id": "index_credircardwarder_validate", "label": ".validate()", "color": {"background": "#4E79A7", "border": "#4E79A7", "highlight": {"background": "#ffffff", "border": "#4E79A7"}}, "size": 10.0, "font": {"size": 0, "color": "#ffffff"}, "title": ".validate()", "community": 10, "community_name": "Community 10", "source_file": "index.js", "file_type": "code", "degree": 0}, {"id": "package", "label": "package.json", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 40.0, "font": {"size": 12, "color": "#ffffff"}, "title": "package.json", "community": 1, "community_name": "Community 1", "source_file": "package.json", "file_type": "code", "degree": 13}, {"id": "package_name", "label": "name", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "name", "community": 1, "community_name": "Community 1", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_version", "label": "version", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "version", "community": 1, "community_name": "Community 1", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_description", "label": "description", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "description", "community": 1, "community_name": "Community 1", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_main", "label": "main", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "main", "community": 1, "community_name": "Community 1", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_scripts", "label": "scripts", "color": {"background": "#76B7B2", "border": "#76B7B2", "highlight": {"background": "#ffffff", "border": "#76B7B2"}}, "size": 21.5, "font": {"size": 12, "color": "#ffffff"}, "title": "scripts", "community": 3, "community_name": "Community 3", "source_file": "package.json", "file_type": "code", "degree": 5}, {"id": "package_scripts_test", "label": "test", "color": {"background": "#76B7B2", "border": "#76B7B2", "highlight": {"background": "#ffffff", "border": "#76B7B2"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "test", "community": 3, "community_name": "Community 3", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_scripts_test_browser", "label": "test-browser", "color": {"background": "#76B7B2", "border": "#76B7B2", "highlight": {"background": "#ffffff", "border": "#76B7B2"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "test-browser", "community": 3, "community_name": "Community 3", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_scripts_build", "label": "build", "color": {"background": "#76B7B2", "border": "#76B7B2", "highlight": {"background": "#ffffff", "border": "#76B7B2"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "build", "community": 3, "community_name": "Community 3", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_scripts_watch", "label": "watch", "color": {"background": "#76B7B2", "border": "#76B7B2", "highlight": {"background": "#ffffff", "border": "#76B7B2"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "watch", "community": 3, "community_name": "Community 3", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_contributors", "label": "contributors", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "contributors", "community": 1, "community_name": "Community 1", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_repository", "label": "repository", "color": {"background": "#FF9DA7", "border": "#FF9DA7", "highlight": {"background": "#ffffff", "border": "#FF9DA7"}}, "size": 16.9, "font": {"size": 12, "color": "#ffffff"}, "title": "repository", "community": 7, "community_name": "Community 7", "source_file": "package.json", "file_type": "code", "degree": 3}, {"id": "package_repository_type", "label": "type", "color": {"background": "#FF9DA7", "border": "#FF9DA7", "highlight": {"background": "#ffffff", "border": "#FF9DA7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "type", "community": 7, "community_name": "Community 7", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_repository_url", "label": "url", "color": {"background": "#FF9DA7", "border": "#FF9DA7", "highlight": {"background": "#ffffff", "border": "#FF9DA7"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "url", "community": 7, "community_name": "Community 7", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_keywords", "label": "keywords", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "keywords", "community": 1, "community_name": "Community 1", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_license", "label": "license", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "license", "community": 1, "community_name": "Community 1", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_dependencies", "label": "dependencies", "color": {"background": "#B07AA1", "border": "#B07AA1", "highlight": {"background": "#ffffff", "border": "#B07AA1"}}, "size": 16.9, "font": {"size": 12, "color": "#ffffff"}, "title": "dependencies", "community": 6, "community_name": "Community 6", "source_file": "package.json", "file_type": "code", "degree": 3}, {"id": "package_dependencies_lodash_find", "label": "lodash.find", "color": {"background": "#B07AA1", "border": "#B07AA1", "highlight": {"background": "#ffffff", "border": "#B07AA1"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "lodash.find", "community": 6, "community_name": "Community 6", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_dependencies_luhn", "label": "luhn", "color": {"background": "#B07AA1", "border": "#B07AA1", "highlight": {"background": "#ffffff", "border": "#B07AA1"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "luhn", "community": 6, "community_name": "Community 6", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_devdependencies", "label": "devDependencies", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 28.5, "font": {"size": 12, "color": "#ffffff"}, "title": "devDependencies", "community": 2, "community_name": "Community 2", "source_file": "package.json", "file_type": "code", "degree": 8}, {"id": "package_devdependencies_mocha", "label": "mocha", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "mocha", "community": 2, "community_name": "Community 2", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_devdependencies_rollup", "label": "rollup", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "rollup", "community": 2, "community_name": "Community 2", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_devdependencies_rollup_plugin_commonjs", "label": "rollup-plugin-commonjs", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "rollup-plugin-commonjs", "community": 2, "community_name": "Community 2", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_devdependencies_rollup_plugin_node_resolve", "label": "rollup-plugin-node-resolve", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "rollup-plugin-node-resolve", "community": 2, "community_name": "Community 2", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_devdependencies_rollup_plugin_uglify", "label": "rollup-plugin-uglify", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "rollup-plugin-uglify", "community": 2, "community_name": "Community 2", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_devdependencies_testling", "label": "testling", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "testling", "community": 2, "community_name": "Community 2", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_devdependencies_xo", "label": "xo", "color": {"background": "#E15759", "border": "#E15759", "highlight": {"background": "#ffffff", "border": "#E15759"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "xo", "community": 2, "community_name": "Community 2", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_testling", "label": "testling", "color": {"background": "#59A14F", "border": "#59A14F", "highlight": {"background": "#ffffff", "border": "#59A14F"}}, "size": 19.2, "font": {"size": 12, "color": "#ffffff"}, "title": "testling", "community": 4, "community_name": "Community 4", "source_file": "package.json", "file_type": "code", "degree": 4}, {"id": "package_testling_harness", "label": "harness", "color": {"background": "#59A14F", "border": "#59A14F", "highlight": {"background": "#ffffff", "border": "#59A14F"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "harness", "community": 4, "community_name": "Community 4", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_testling_files", "label": "files", "color": {"background": "#59A14F", "border": "#59A14F", "highlight": {"background": "#ffffff", "border": "#59A14F"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "files", "community": 4, "community_name": "Community 4", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_testling_browsers", "label": "browsers", "color": {"background": "#59A14F", "border": "#59A14F", "highlight": {"background": "#ffffff", "border": "#59A14F"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "browsers", "community": 4, "community_name": "Community 4", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_xo", "label": "xo", "color": {"background": "#EDC948", "border": "#EDC948", "highlight": {"background": "#ffffff", "border": "#EDC948"}}, "size": 19.2, "font": {"size": 12, "color": "#ffffff"}, "title": "xo", "community": 5, "community_name": "Community 5", "source_file": "package.json", "file_type": "code", "degree": 4}, {"id": "package_xo_esnext", "label": "esnext", "color": {"background": "#EDC948", "border": "#EDC948", "highlight": {"background": "#ffffff", "border": "#EDC948"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "esnext", "community": 5, "community_name": "Community 5", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_xo_space", "label": "space", "color": {"background": "#EDC948", "border": "#EDC948", "highlight": {"background": "#ffffff", "border": "#EDC948"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "space", "community": 5, "community_name": "Community 5", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "package_xo_envs", "label": "envs", "color": {"background": "#EDC948", "border": "#EDC948", "highlight": {"background": "#ffffff", "border": "#EDC948"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "envs", "community": 5, "community_name": "Community 5", "source_file": "package.json", "file_type": "code", "degree": 1}, {"id": "rollup_config", "label": "rollup.config.js", "color": {"background": "#F28E2B", "border": "#F28E2B", "highlight": {"background": "#ffffff", "border": "#F28E2B"}}, "size": 10.0, "font": {"size": 0, "color": "#ffffff"}, "title": "rollup.config.js", "community": 11, "community_name": "Community 11", "source_file": "rollup.config.js", "file_type": "code", "degree": 0}, {"id": "test_test", "label": "test.js", "color": {"background": "#9C755F", "border": "#9C755F", "highlight": {"background": "#ffffff", "border": "#9C755F"}}, "size": 12.3, "font": {"size": 0, "color": "#ffffff"}, "title": "test.js", "community": 8, "community_name": "Community 8", "source_file": "test/test.js", "file_type": "code", "degree": 1}];
+const RAW_EDGES = [{"from": "bower", "to": "bower_authors", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "bower", "to": "bower_description", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "bower", "to": "bower_homepage", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "bower", "to": "bower_ignore", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "bower", "to": "bower_keywords", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "bower", "to": "bower_license", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "bower", "to": "bower_main", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "bower", "to": "bower_name", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "index", "to": "test_test", "label": "imports_from", "title": "imports_from [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "index_credircardwarder_getrule", "to": "index_credircardwarder_getbrand", "label": "calls", "title": "calls [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_contributors", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_dependencies", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_description", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_devdependencies", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_keywords", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_license", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_main", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_name", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_repository", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_scripts", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_testling", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_version", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package", "to": "package_xo", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_scripts", "to": "package_scripts_build", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_scripts", "to": "package_scripts_test", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_scripts", "to": "package_scripts_test_browser", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_scripts", "to": "package_scripts_watch", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_repository", "to": "package_repository_type", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_repository", "to": "package_repository_url", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_dependencies", "to": "package_dependencies_lodash_find", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_dependencies", "to": "package_dependencies_luhn", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_devdependencies", "to": "package_devdependencies_mocha", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_devdependencies", "to": "package_devdependencies_rollup", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_devdependencies", "to": "package_devdependencies_rollup_plugin_commonjs", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_devdependencies", "to": "package_devdependencies_rollup_plugin_node_resolve", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_devdependencies", "to": "package_devdependencies_rollup_plugin_uglify", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_devdependencies", "to": "package_devdependencies_testling", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_devdependencies", "to": "package_devdependencies_xo", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_testling", "to": "package_testling_browsers", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_testling", "to": "package_testling_files", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_testling", "to": "package_testling_harness", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_xo", "to": "package_xo_envs", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_xo", "to": "package_xo_esnext", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}, {"from": "package_xo", "to": "package_xo_space", "label": "contains", "title": "contains [EXTRACTED]", "dashes": false, "width": 2, "color": {"opacity": 0.7}, "confidence": "EXTRACTED"}];
+const LEGEND = [{"cid": 0, "color": "#4E79A7", "label": "Community 0", "count": 9}, {"cid": 1, "color": "#F28E2B", "label": "Community 1", "count": 8}, {"cid": 2, "color": "#E15759", "label": "Community 2", "count": 8}, {"cid": 3, "color": "#76B7B2", "label": "Community 3", "count": 5}, {"cid": 4, "color": "#59A14F", "label": "Community 4", "count": 4}, {"cid": 5, "color": "#EDC948", "label": "Community 5", "count": 4}, {"cid": 6, "color": "#B07AA1", "label": "Community 6", "count": 3}, {"cid": 7, "color": "#FF9DA7", "label": "Community 7", "count": 3}, {"cid": 8, "color": "#9C755F", "label": "Community 8", "count": 2}, {"cid": 9, "color": "#BAB0AC", "label": "Community 9", "count": 2}, {"cid": 10, "color": "#4E79A7", "label": "Community 10", "count": 1}, {"cid": 11, "color": "#F28E2B", "label": "Community 11", "count": 1}];
+
+// HTML-escape helper — prevents XSS when injecting graph data into innerHTML
+function esc(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+// Build vis datasets
+const nodesDS = new vis.DataSet(RAW_NODES.map(n => ({
+  id: n.id, label: n.label, color: n.color, size: n.size,
+  font: n.font, title: n.title,
+  _community: n.community, _community_name: n.community_name,
+  _source_file: n.source_file, _file_type: n.file_type, _degree: n.degree,
+})));
+
+const edgesDS = new vis.DataSet(RAW_EDGES.map((e, i) => ({
+  id: i, from: e.from, to: e.to,
+  label: '',
+  title: e.title,
+  dashes: e.dashes,
+  width: e.width,
+  color: e.color,
+  arrows: { to: { enabled: true, scaleFactor: 0.5 } },
+})));
+
+const container = document.getElementById('graph');
+const network = new vis.Network(container, { nodes: nodesDS, edges: edgesDS }, {
+  physics: {
+    enabled: true,
+    solver: 'forceAtlas2Based',
+    forceAtlas2Based: {
+      gravitationalConstant: -60,
+      centralGravity: 0.005,
+      springLength: 120,
+      springConstant: 0.08,
+      damping: 0.4,
+      avoidOverlap: 0.8,
+    },
+    stabilization: { iterations: 200, fit: true },
+  },
+  interaction: {
+    hover: true,
+    tooltipDelay: 100,
+    hideEdgesOnDrag: true,
+    navigationButtons: false,
+    keyboard: false,
+  },
+  nodes: { shape: 'dot', borderWidth: 1.5 },
+  edges: { smooth: { type: 'continuous', roundness: 0.2 }, selectionWidth: 3 },
+});
+
+network.once('stabilizationIterationsDone', () => {
+  network.setOptions({ physics: { enabled: false } });
+});
+
+function showInfo(nodeId) {
+  const n = nodesDS.get(nodeId);
+  if (!n) return;
+  const neighborIds = network.getConnectedNodes(nodeId);
+  const neighborItems = neighborIds.map(nid => {
+    const nb = nodesDS.get(nid);
+    const color = nb ? nb.color.background : '#555';
+    return `<span class="neighbor-link" style="border-left-color:${esc(color)}" onclick="focusNode(${JSON.stringify(nid)})">${esc(nb ? nb.label : nid)}</span>`;
+  }).join('');
+  document.getElementById('info-content').innerHTML = `
+    <div class="field"><b>${esc(n.label)}</b></div>
+    <div class="field">Type: ${esc(n._file_type || 'unknown')}</div>
+    <div class="field">Community: ${esc(n._community_name)}</div>
+    <div class="field">Source: ${esc(n._source_file || '-')}</div>
+    <div class="field">Degree: ${n._degree}</div>
+    ${neighborIds.length ? `<div class="field" style="margin-top:8px;color:#aaa;font-size:11px">Neighbors (${neighborIds.length})</div><div id="neighbors-list">${neighborItems}</div>` : ''}
+  `;
+}
+
+function focusNode(nodeId) {
+  network.focus(nodeId, { scale: 1.4, animation: true });
+  network.selectNodes([nodeId]);
+  showInfo(nodeId);
+}
+
+// Track hovered node — hover detection is more reliable than click params
+let hoveredNodeId = null;
+network.on('hoverNode', params => {
+  hoveredNodeId = params.node;
+  container.style.cursor = 'pointer';
+});
+network.on('blurNode', () => {
+  hoveredNodeId = null;
+  container.style.cursor = 'default';
+});
+container.addEventListener('click', () => {
+  if (hoveredNodeId !== null) {
+    showInfo(hoveredNodeId);
+    network.selectNodes([hoveredNodeId]);
+  }
+});
+network.on('click', params => {
+  if (params.nodes.length > 0) {
+    showInfo(params.nodes[0]);
+  } else if (hoveredNodeId === null) {
+    document.getElementById('info-content').innerHTML = '<span class="empty">Click a node to inspect it</span>';
+  }
+});
+
+const searchInput = document.getElementById('search');
+const searchResults = document.getElementById('search-results');
+searchInput.addEventListener('input', () => {
+  const q = searchInput.value.toLowerCase().trim();
+  searchResults.innerHTML = '';
+  if (!q) { searchResults.style.display = 'none'; return; }
+  const matches = RAW_NODES.filter(n => n.label.toLowerCase().includes(q)).slice(0, 20);
+  if (!matches.length) { searchResults.style.display = 'none'; return; }
+  searchResults.style.display = 'block';
+  matches.forEach(n => {
+    const el = document.createElement('div');
+    el.className = 'search-item';
+    el.textContent = n.label;
+    el.style.borderLeft = `3px solid ${n.color.background}`;
+    el.style.paddingLeft = '8px';
+    el.onclick = () => {
+      network.focus(n.id, { scale: 1.5, animation: true });
+      network.selectNodes([n.id]);
+      showInfo(n.id);
+      searchResults.style.display = 'none';
+      searchInput.value = '';
+    };
+    searchResults.appendChild(el);
+  });
+});
+document.addEventListener('click', e => {
+  if (!searchResults.contains(e.target) && e.target !== searchInput)
+    searchResults.style.display = 'none';
+});
+
+const hiddenCommunities = new Set();
+
+const selectAllCb = document.getElementById('select-all-cb');
+
+function updateSelectAllState() {
+  const total = LEGEND.length;
+  const hidden = hiddenCommunities.size;
+  selectAllCb.checked = hidden === 0;
+  selectAllCb.indeterminate = hidden > 0 && hidden < total;
+}
+
+function toggleAllCommunities(hide) {
+  document.querySelectorAll('.legend-item').forEach(item => {
+    hide ? item.classList.add('dimmed') : item.classList.remove('dimmed');
+  });
+  document.querySelectorAll('.legend-cb').forEach(cb => {
+    cb.checked = !hide;
+  });
+  LEGEND.forEach(c => {
+    if (hide) hiddenCommunities.add(c.cid); else hiddenCommunities.delete(c.cid);
+  });
+  const updates = RAW_NODES.map(n => ({ id: n.id, hidden: hide }));
+  nodesDS.update(updates);
+  updateSelectAllState();
+}
+
+const legendEl = document.getElementById('legend');
+LEGEND.forEach(c => {
+  const item = document.createElement('div');
+  item.className = 'legend-item';
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.className = 'legend-cb';
+  cb.checked = true;
+  cb.addEventListener('change', (e) => {
+    e.stopPropagation();
+    if (cb.checked) {
+      hiddenCommunities.delete(c.cid);
+      item.classList.remove('dimmed');
+    } else {
+      hiddenCommunities.add(c.cid);
+      item.classList.add('dimmed');
+    }
+    const updates = RAW_NODES
+      .filter(n => n.community === c.cid)
+      .map(n => ({ id: n.id, hidden: !cb.checked }));
+    nodesDS.update(updates);
+    updateSelectAllState();
+  });
+  item.innerHTML = `<div class="legend-dot" style="background:${c.color}"></div>
+    <span class="legend-label">${c.label}</span>
+    <span class="legend-count">${c.count}</span>`;
+  item.prepend(cb);
+  item.onclick = (e) => {
+    if (e.target === cb) return;
+    cb.checked = !cb.checked;
+    cb.dispatchEvent(new Event('change'));
+  };
+  legendEl.appendChild(item);
+});
+</script>
+<script>
+// Render hyperedges as shaded regions
+const hyperedges = [];
+// afterDrawing passes ctx already transformed to network coordinate space.
+// Draw node positions raw — no manual pan/zoom/DPR math needed.
+network.on('afterDrawing', function(ctx) {
+    hyperedges.forEach(h => {
+        const positions = h.nodes
+            .map(nid => network.getPositions([nid])[nid])
+            .filter(p => p !== undefined);
+        if (positions.length < 2) return;
+        ctx.save();
+        ctx.globalAlpha = 0.12;
+        ctx.fillStyle = '#6366f1';
+        ctx.strokeStyle = '#6366f1';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        // Centroid and expanded hull in network coordinates
+        const cx = positions.reduce((s, p) => s + p.x, 0) / positions.length;
+        const cy = positions.reduce((s, p) => s + p.y, 0) / positions.length;
+        const expanded = positions.map(p => ({
+            x: cx + (p.x - cx) * 1.15,
+            y: cy + (p.y - cy) * 1.15
+        }));
+        ctx.moveTo(expanded[0].x, expanded[0].y);
+        expanded.slice(1).forEach(p => ctx.lineTo(p.x, p.y));
+        ctx.closePath();
+        ctx.fill();
+        ctx.globalAlpha = 0.4;
+        ctx.stroke();
+        // Label
+        ctx.globalAlpha = 0.8;
+        ctx.fillStyle = '#4f46e5';
+        ctx.font = 'bold 11px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(h.label, cx, cy - 5);
+        ctx.restore();
+    });
+});
+</script>
+</body>
+</html>

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1,0 +1,953 @@
+{
+  "directed": false,
+  "multigraph": false,
+  "graph": {},
+  "nodes": [
+    {
+      "label": "bower.json",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "bower",
+      "community": 0,
+      "norm_label": "bower.json"
+    },
+    {
+      "label": "name",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L2",
+      "_origin": "ast",
+      "id": "bower_name",
+      "community": 0,
+      "norm_label": "name"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L3",
+      "_origin": "ast",
+      "id": "bower_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "main",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L4",
+      "_origin": "ast",
+      "id": "bower_main",
+      "community": 0,
+      "norm_label": "main"
+    },
+    {
+      "label": "authors",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "bower_authors",
+      "community": 0,
+      "norm_label": "authors"
+    },
+    {
+      "label": "license",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L11",
+      "_origin": "ast",
+      "id": "bower_license",
+      "community": 0,
+      "norm_label": "license"
+    },
+    {
+      "label": "keywords",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L12",
+      "_origin": "ast",
+      "id": "bower_keywords",
+      "community": 0,
+      "norm_label": "keywords"
+    },
+    {
+      "label": "homepage",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L18",
+      "_origin": "ast",
+      "id": "bower_homepage",
+      "community": 0,
+      "norm_label": "homepage"
+    },
+    {
+      "label": "ignore",
+      "file_type": "code",
+      "source_file": "bower.json",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "bower_ignore",
+      "community": 0,
+      "norm_label": "ignore"
+    },
+    {
+      "label": "index.js",
+      "file_type": "code",
+      "source_file": "index.js",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "index",
+      "community": 8,
+      "norm_label": "index.js"
+    },
+    {
+      "label": ".getRule()",
+      "file_type": "code",
+      "source_file": "index.js",
+      "source_location": "L88",
+      "_origin": "ast",
+      "id": "index_credircardwarder_getrule",
+      "community": 9,
+      "norm_label": ".getrule()"
+    },
+    {
+      "label": ".getBrand()",
+      "file_type": "code",
+      "source_file": "index.js",
+      "source_location": "L98",
+      "_origin": "ast",
+      "id": "index_credircardwarder_getbrand",
+      "community": 9,
+      "norm_label": ".getbrand()"
+    },
+    {
+      "label": ".validate()",
+      "file_type": "code",
+      "source_file": "index.js",
+      "source_location": "L102",
+      "_origin": "ast",
+      "id": "index_credircardwarder_validate",
+      "community": 10,
+      "norm_label": ".validate()"
+    },
+    {
+      "label": "package.json",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "package",
+      "community": 1,
+      "norm_label": "package.json"
+    },
+    {
+      "label": "name",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L2",
+      "_origin": "ast",
+      "id": "package_name",
+      "community": 1,
+      "norm_label": "name"
+    },
+    {
+      "label": "version",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L3",
+      "_origin": "ast",
+      "id": "package_version",
+      "community": 1,
+      "norm_label": "version"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L4",
+      "_origin": "ast",
+      "id": "package_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "main",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "package_main",
+      "community": 1,
+      "norm_label": "main"
+    },
+    {
+      "label": "scripts",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "package_scripts",
+      "community": 3,
+      "norm_label": "scripts"
+    },
+    {
+      "label": "test",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "package_scripts_test",
+      "community": 3,
+      "norm_label": "test"
+    },
+    {
+      "label": "test-browser",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L8",
+      "_origin": "ast",
+      "id": "package_scripts_test_browser",
+      "community": 3,
+      "norm_label": "test-browser"
+    },
+    {
+      "label": "build",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "package_scripts_build",
+      "community": 3,
+      "norm_label": "build"
+    },
+    {
+      "label": "watch",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "package_scripts_watch",
+      "community": 3,
+      "norm_label": "watch"
+    },
+    {
+      "label": "contributors",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L12",
+      "_origin": "ast",
+      "id": "package_contributors",
+      "community": 1,
+      "norm_label": "contributors"
+    },
+    {
+      "label": "repository",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L33",
+      "_origin": "ast",
+      "id": "package_repository",
+      "community": 7,
+      "norm_label": "repository"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L34",
+      "_origin": "ast",
+      "id": "package_repository_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "url",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L35",
+      "_origin": "ast",
+      "id": "package_repository_url",
+      "community": 7,
+      "norm_label": "url"
+    },
+    {
+      "label": "keywords",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "package_keywords",
+      "community": 1,
+      "norm_label": "keywords"
+    },
+    {
+      "label": "license",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L43",
+      "_origin": "ast",
+      "id": "package_license",
+      "community": 1,
+      "norm_label": "license"
+    },
+    {
+      "label": "dependencies",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L44",
+      "_origin": "ast",
+      "id": "package_dependencies",
+      "community": 6,
+      "norm_label": "dependencies"
+    },
+    {
+      "label": "lodash.find",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L45",
+      "_origin": "ast",
+      "id": "package_dependencies_lodash_find",
+      "community": 6,
+      "norm_label": "lodash.find"
+    },
+    {
+      "label": "luhn",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L46",
+      "_origin": "ast",
+      "id": "package_dependencies_luhn",
+      "community": 6,
+      "norm_label": "luhn"
+    },
+    {
+      "label": "devDependencies",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L48",
+      "_origin": "ast",
+      "id": "package_devdependencies",
+      "community": 2,
+      "norm_label": "devdependencies"
+    },
+    {
+      "label": "mocha",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L49",
+      "_origin": "ast",
+      "id": "package_devdependencies_mocha",
+      "community": 2,
+      "norm_label": "mocha"
+    },
+    {
+      "label": "rollup",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L50",
+      "_origin": "ast",
+      "id": "package_devdependencies_rollup",
+      "community": 2,
+      "norm_label": "rollup"
+    },
+    {
+      "label": "rollup-plugin-commonjs",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L51",
+      "_origin": "ast",
+      "id": "package_devdependencies_rollup_plugin_commonjs",
+      "community": 2,
+      "norm_label": "rollup-plugin-commonjs"
+    },
+    {
+      "label": "rollup-plugin-node-resolve",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L52",
+      "_origin": "ast",
+      "id": "package_devdependencies_rollup_plugin_node_resolve",
+      "community": 2,
+      "norm_label": "rollup-plugin-node-resolve"
+    },
+    {
+      "label": "rollup-plugin-uglify",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L53",
+      "_origin": "ast",
+      "id": "package_devdependencies_rollup_plugin_uglify",
+      "community": 2,
+      "norm_label": "rollup-plugin-uglify"
+    },
+    {
+      "label": "testling",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L54",
+      "_origin": "ast",
+      "id": "package_devdependencies_testling",
+      "community": 2,
+      "norm_label": "testling"
+    },
+    {
+      "label": "xo",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L55",
+      "_origin": "ast",
+      "id": "package_devdependencies_xo",
+      "community": 2,
+      "norm_label": "xo"
+    },
+    {
+      "label": "testling",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L57",
+      "_origin": "ast",
+      "id": "package_testling",
+      "community": 4,
+      "norm_label": "testling"
+    },
+    {
+      "label": "harness",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L58",
+      "_origin": "ast",
+      "id": "package_testling_harness",
+      "community": 4,
+      "norm_label": "harness"
+    },
+    {
+      "label": "files",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L59",
+      "_origin": "ast",
+      "id": "package_testling_files",
+      "community": 4,
+      "norm_label": "files"
+    },
+    {
+      "label": "browsers",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L60",
+      "_origin": "ast",
+      "id": "package_testling_browsers",
+      "community": 4,
+      "norm_label": "browsers"
+    },
+    {
+      "label": "xo",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L65",
+      "_origin": "ast",
+      "id": "package_xo",
+      "community": 5,
+      "norm_label": "xo"
+    },
+    {
+      "label": "esnext",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L66",
+      "_origin": "ast",
+      "id": "package_xo_esnext",
+      "community": 5,
+      "norm_label": "esnext"
+    },
+    {
+      "label": "space",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L67",
+      "_origin": "ast",
+      "id": "package_xo_space",
+      "community": 5,
+      "norm_label": "space"
+    },
+    {
+      "label": "envs",
+      "file_type": "code",
+      "source_file": "package.json",
+      "source_location": "L68",
+      "_origin": "ast",
+      "id": "package_xo_envs",
+      "community": 5,
+      "norm_label": "envs"
+    },
+    {
+      "label": "rollup.config.js",
+      "file_type": "code",
+      "source_file": "rollup.config.js",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "rollup_config",
+      "community": 11,
+      "norm_label": "rollup.config.js"
+    },
+    {
+      "label": "test.js",
+      "file_type": "code",
+      "source_file": "test/test.js",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "test_test",
+      "community": 8,
+      "norm_label": "test.js"
+    }
+  ],
+  "links": [
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "bower.json",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "bower",
+      "target": "bower_authors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "bower.json",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "bower",
+      "target": "bower_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "bower.json",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "bower",
+      "target": "bower_homepage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "bower.json",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "bower",
+      "target": "bower_ignore",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "bower.json",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "bower",
+      "target": "bower_keywords",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "bower.json",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "bower",
+      "target": "bower_license",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "bower.json",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "bower",
+      "target": "bower_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "bower.json",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "bower",
+      "target": "bower_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "test/test.js",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "test_test",
+      "target": "index",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "index.js",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "index_credircardwarder_getbrand",
+      "target": "index_credircardwarder_getrule",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_contributors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L44",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_dependencies",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_devdependencies",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_keywords",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_license",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_repository",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_scripts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_testling",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "package",
+      "target": "package_xo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "package_scripts",
+      "target": "package_scripts_build",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "package_scripts",
+      "target": "package_scripts_test",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "package_scripts",
+      "target": "package_scripts_test_browser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "package_scripts",
+      "target": "package_scripts_watch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L34",
+      "weight": 1.0,
+      "source": "package_repository",
+      "target": "package_repository_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "package_repository",
+      "target": "package_repository_url",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "package_dependencies",
+      "target": "package_dependencies_lodash_find",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "package_dependencies",
+      "target": "package_dependencies_luhn",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "package_devdependencies",
+      "target": "package_devdependencies_mocha",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "package_devdependencies",
+      "target": "package_devdependencies_rollup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L51",
+      "weight": 1.0,
+      "source": "package_devdependencies",
+      "target": "package_devdependencies_rollup_plugin_commonjs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "package_devdependencies",
+      "target": "package_devdependencies_rollup_plugin_node_resolve",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "package_devdependencies",
+      "target": "package_devdependencies_rollup_plugin_uglify",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L54",
+      "weight": 1.0,
+      "source": "package_devdependencies",
+      "target": "package_devdependencies_testling",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "package_devdependencies",
+      "target": "package_devdependencies_xo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "package_testling",
+      "target": "package_testling_browsers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "package_testling",
+      "target": "package_testling_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "package_testling",
+      "target": "package_testling_harness",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L68",
+      "weight": 1.0,
+      "source": "package_xo",
+      "target": "package_xo_envs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "package_xo",
+      "target": "package_xo_esnext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "package.json",
+      "source_location": "L67",
+      "weight": 1.0,
+      "source": "package_xo",
+      "target": "package_xo_space",
+      "confidence_score": 1.0
+    }
+  ],
+  "hyperedges": [],
+  "built_at_commit": "daef10254f3d8e7223a004556e0b6a001f1f9b02"
+}

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,0 +1,32 @@
+{
+  "bower.json": {
+    "mtime": 1783875364.0,
+    "ast_hash": "d6dab5f8b50d32f24af2ae0235061b68",
+    "semantic_hash": "d6dab5f8b50d32f24af2ae0235061b68"
+  },
+  "index.js": {
+    "mtime": 1783875364.0,
+    "ast_hash": "1c635b040cd10bb830fe3c042eafdaea",
+    "semantic_hash": "1c635b040cd10bb830fe3c042eafdaea"
+  },
+  "package.json": {
+    "mtime": 1783875364.0,
+    "ast_hash": "0d67996602ba8ecca74d201fc73d4860",
+    "semantic_hash": "0d67996602ba8ecca74d201fc73d4860"
+  },
+  "rollup.config.js": {
+    "mtime": 1783875364.0,
+    "ast_hash": "9494df0ee78da0abc4cb66154430b92b",
+    "semantic_hash": "9494df0ee78da0abc4cb66154430b92b"
+  },
+  "test/test.js": {
+    "mtime": 1783875364.0,
+    "ast_hash": "ca6da46bc1576ff8dcccb359ff25cd34",
+    "semantic_hash": "ca6da46bc1576ff8dcccb359ff25cd34"
+  },
+  "README.md": {
+    "mtime": 1783875364.0,
+    "ast_hash": "ee5aa2fcec13098e39d5ef9075092b3f",
+    "semantic_hash": "ee5aa2fcec13098e39d5ef9075092b3f"
+  }
+}

--- a/graphify-out/triage-info.json
+++ b/graphify-out/triage-info.json
@@ -1,0 +1,46 @@
+{
+  "repo": "creditcard-warder",
+  "last_commit": "2019-10-23 18:32:39 -0300",
+  "last_author": "Paula Pinheiro",
+  "commits": "37",
+  "code_files": 5,
+  "doc_files": 1,
+  "has_serverless": false,
+  "has_pipeline": false,
+  "has_dockerfile": false,
+  "pkg_name": "creditcard-warder",
+  "deps": [
+    "lodash.find",
+    "luhn"
+  ],
+  "graph_nodes": 50,
+  "graph_edges": 44,
+  "communities": 12,
+  "god_nodes": [
+    {
+      "id": "package_scripts",
+      "label": "scripts",
+      "degree": 5
+    },
+    {
+      "id": "package_testling",
+      "label": "testling",
+      "degree": 4
+    },
+    {
+      "id": "package_xo",
+      "label": "xo",
+      "degree": 4
+    },
+    {
+      "id": "package_repository",
+      "label": "repository",
+      "degree": 3
+    },
+    {
+      "id": "bower_main",
+      "label": "main",
+      "degree": 1
+    }
+  ]
+}


### PR DESCRIPTION
## O que é este PR

Mapeamento big-picture (NA-598) do repo `creditcard-warder`: knowledge graph, scan
código→realidade, CLAUDE.md, PRCs e pipeline de qualidade consultivo. Sem mudança de
comportamento — só documentação/observabilidade/CI consultivo.

## O que o repo é

Biblioteca JS standalone (publicada no npm como `creditcard-warder`) que identifica a
bandeira de um cartão de crédito a partir do número (tabela de regex por BIN — Elo,
Hipercard, Aura, Visa Electron, Maestro, Forbrugsforeningen, Dankort, Visa, Mastercard,
Amex, Dinersclub, Discover, Unionpay, JCB) e valida via checksum de Luhn. Sem servidor,
sem banco, sem recurso AWS próprio.

## Onde é usado

- **apoia.se** (monolito): dependência direta, server-side em
  `modules/mundipagg/subscription.js` e client-side via bundle vendorizado
  (`public/lib/creditcard-warder/dist/`).
- **apoiase-client**: dependência direta, usada nos campos de formulário
  `card-number`/`card-cvv` (React) para exibir bandeira e validar em tempo real.

## Achados do scan

- Sem `serverless.yml`/Dockerfile/IaC — confirmado que não há deploy próprio. Cruzamento
  com os snapshots Steampipe da rodada (lambdas/cfn-stacks/s3/sqs/apigw/eventrules/sns/
  dynamodb) não encontrou nenhum recurso AWS com esse nome.
- O `apoiase-context-layer` lista este repo no subgrafo "Serverless — Cobrança" da
  topologia — divergência: é lib consumida como dependência de código, não um serviço
  deployado. Anotado no PRC de AWS para correção futura do context-layer (fora do
  escopo deste PR).
- `test/test.js` usa números de cartão de **teste públicos** padrão da indústria de
  pagamentos (não PANs reais) — relevante por ser repo de escopo PCI, documentado no PRC
  de segurança.
- `gitleaks detect` (working tree + histórico completo) não encontrou nenhum secret.

## Pipeline

`.github/workflows/quality-gates.yml` novo: gitleaks + Semgrep + Trivy, todos os steps
com `continue-on-error: true` — 100% consultivo, não bloqueia. Repo não tinha nenhum
workflow prévio.

## Pendências

- Add reviewer manual (time GitHub não definido nesta rodada).
- Devdeps desatualizadas (`xo@0.15.0`, `rollup@^0.66.2`, `mocha@^3.2.0`) — débito
  registrado no PRC de segurança, sem urgência.